### PR TITLE
fix: fixed python interpreter path can not always works well. #6

### DIFF
--- a/uam/app_service.py
+++ b/uam/app_service.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import os
 import stat
+import sys
 
 import docker
 import daiquiri
@@ -88,7 +89,8 @@ def create_app_wrapper(app):
                 'app': app,
                 'entrypoint': entry,
                 'volumes': app.volumes,
-                'configs': app.configs
+                'configs': app.configs,
+                'python_path': sys.executable
             })
             f_handler.write(content.encode('utf-8'))
 

--- a/uam/excutable_app.tmpl
+++ b/uam/excutable_app.tmpl
@@ -1,4 +1,4 @@
-#!/usr/local/bin/python
+#!{{ python_path }}
 # -*- coding: utf-8 -*-
 import os
 import json


### PR DESCRIPTION
use `sys.executable` dynamic find current os's python path.